### PR TITLE
add initWithCode and init AXStretchableHeaderTabViewController's view…

### DIFF
--- a/Classes/AXStretchableHeaderTabViewController.h
+++ b/Classes/AXStretchableHeaderTabViewController.h
@@ -24,6 +24,9 @@
 @property (weak, nonatomic) IBOutlet UIScrollView *containerView;
 @property (nonatomic) BOOL shouldBounceHeaderView;
 
+// only call after view has appeared
+- (void)switchToIndex:(NSUInteger)index;
+
 // Layout
 - (void)layoutHeaderViewAndTabBar;
 - (void)layoutViewControllers;

--- a/Classes/AXStretchableHeaderTabViewController.m
+++ b/Classes/AXStretchableHeaderTabViewController.m
@@ -15,26 +15,48 @@ static NSString * const AXStretchableHeaderTabViewControllerSelectedIndexKey = @
   CGFloat _headerViewTopConstraintConstant;
 }
 
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
-{
-  // MEMO:
-  // An inherited class does not load xib file.
-  // So, this code assigns class name of AXStretchableHeaderTabViewController clearly.
-  self = [super initWithNibName:NSStringFromClass([AXStretchableHeaderTabViewController class]) bundle:nibBundleOrNil];
-  if (self) {
-    // Custom initialization
-    _shouldBounceHeaderView = YES;
+//- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+//{
+//  // MEMO:
+//  // An inherited class does not load xib file.
+//  // So, this code assigns class name of AXStretchableHeaderTabViewController clearly.
+//  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+//  if (self) {
+//      
+//  }
+//  return self;
+//}
 
-    _tabBar = [[AXTabBar alloc] init];
-    [_tabBar setDelegate:self];
-  }
-  return self;
+- (void)switchToIndex:(NSUInteger)index
+{
+    if (self.viewControllers == nil
+        || index >= self.viewControllers.count)
+        return;
+    
+    self.tabBar.selectedItem = self.tabBar.items[index];
+    [self.containerView setContentOffset:(CGPoint) { index *CGRectGetWidth(
+                                                                           self.containerView
+                                                                           .bounds),
+        self.containerView
+        .contentOffset
+        .y } animated:YES];
+    self.selectedIndex = index;
 }
 
 - (void)viewDidLoad
 {
   [super viewDidLoad];
-  
+
+  // Custom initialization
+  [[NSBundle mainBundle] loadNibNamed:NSStringFromClass([AXStretchableHeaderTabViewController class]) owner:self options:nil];
+    
+  _shouldBounceHeaderView = YES;
+
+  if (!_tabBar) {
+    _tabBar = [[AXTabBar alloc] init];
+  }
+    
+  [_tabBar setDelegate:self];
   [_tabBar sizeToFit];
   [self.view addSubview:_tabBar];
 }

--- a/Classes/AXTabBar.m
+++ b/Classes/AXTabBar.m
@@ -23,6 +23,22 @@
 {
   self = [super initWithFrame:frame];
   if (self) {
+      [self commonInit];
+  }
+  return self;
+}
+
+-(id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+-(void)commonInit
+{
     _tabBarButtonFont = [UIFont systemFontOfSize:14.0];
     
     _toolbar = [[UIToolbar alloc] init];
@@ -38,11 +54,9 @@
     _bottomSeparator = [CALayer layer];
     [_bottomSeparator setBackgroundColor:[[UIColor colorWithWhite:0.0 alpha:0.1] CGColor]];
     [self.layer addSublayer:_bottomSeparator];
-
+    
     _indicatorLayer = [CALayer layer];
     [self.layer addSublayer:_indicatorLayer];
-  }
-  return self;
 }
 
 - (void)layoutSubviews

--- a/Classes/AXTabBarItemButton.m
+++ b/Classes/AXTabBarItemButton.m
@@ -12,11 +12,25 @@
   self = [super initWithFrame:frame];
   if (self) {
     // Initialization code
+      [self commonInit];
+  }
+  return self;
+}
+
+-(id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+-(void)commonInit
+{
     [self setTitleColor:[UIColor darkTextColor] forState:UIControlStateNormal];
     [self setTitleColor:[UIColor orangeColor] forState:UIControlStateSelected];
     [self setTitleColor:[UIColor orangeColor] forState:UIControlStateHighlighted];
-  }
-  return self;
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
… in viewDidLoad instead of initWithNibName; add switchToIndex to switch to other child view controller

i hope u would consider my changes:
1. we can draw a UIViewController and set it to AXStretchableHeaderTabViewController, and IB can init it correctly now. since ios will init view controller's view automatically, it's better to do view init work in viewDidLoad instead of initWithNibName. 
2. add switchToIndex function. i call self.selectedIndex = 1 to select a tab, but it doesn't work correctly.
